### PR TITLE
chore: bump release to 0.6.3 (I messed with 0.6.2 and am skipping the…

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v0.1.0
 description: GlueOps Helm Chart for external-secrets with defaults to skip installing CRDs as they are installed separately and changing intervals for a faster deployment
 name: glueops-external-secrets
-version: 0.6.1
+version: 0.6.3
 dependencies:
   - name: external-secrets
     version: 0.9.18

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glueops-external-secrets
 
-![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.6.3](https://img.shields.io/badge/Version-0.6.3-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 GlueOps Helm Chart for external-secrets with defaults to skip installing CRDs as they are installed separately and changing intervals for a faster deployment
 
@@ -8,7 +8,7 @@ GlueOps Helm Chart for external-secrets with defaults to skip installing CRDs as
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.external-secrets.io | external-secrets | 0.9.16 |
+| https://charts.external-secrets.io | external-secrets | 0.9.18 |
 
 ## Values
 


### PR DESCRIPTION
### **User description**
… patch version)


___

### **PR Type**
enhancement


___

### **Description**
- This PR updates the Helm chart version from 0.6.1 to 0.6.3, skipping version 0.6.2.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chart.yaml</strong><dd><code>Bump Helm Chart Version to 0.6.3</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Chart.yaml
- Updated the version of the Helm chart from 0.6.1 to 0.6.3.


</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/platform-helm-chart-external-secrets/pull/29/files#diff-d954583aa4c24cff0039bc948abd7c694fc3dab2030231d11ed1b3cda9b4ddbe">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

